### PR TITLE
add take_attendance switch to events

### DIFF
--- a/src/calendar/components/EventPicker.tsx
+++ b/src/calendar/components/EventPicker.tsx
@@ -72,11 +72,13 @@ const EventPicker: Component<inputs> = (props) => {
         setShowEvents(true)
     }
 
-    type eventData = { eventId: number }
+    type eventData = { eventId: number; takeAttendance: boolean }
     const handleSelectEvent = (data: eventData, event) => {
         event.preventDefault()
-        setShowEvents(false)
-        props.handleSelect(data.eventId)
+        if (data.takeAttendance) {
+            setShowEvents(false)
+            props.handleSelect(data.eventId)
+        }
     }
 
     return (
@@ -156,10 +158,17 @@ const EventPicker: Component<inputs> = (props) => {
                                                 return (
                                                     <div class="mt-2">
                                                         <div
-                                                            class="flex cursor-pointer hover:text-accent-content"
+                                                            class={`flex ${
+                                                                robotEvent.take_attendance === true
+                                                                    ? 'hover:text-accent-content cursor-pointer'
+                                                                    : ''
+                                                            }`}
                                                             onClick={[
                                                                 handleSelectEvent,
-                                                                { eventId: robotEvent.event_id },
+                                                                {
+                                                                    eventId: robotEvent.event_id,
+                                                                    takeAttendance: robotEvent.take_attendance,
+                                                                },
                                                             ]}
                                                         >
                                                             <div class={eventColors[robotEvent.event_type]}>

--- a/src/calendar/components/FullCalendar.tsx
+++ b/src/calendar/components/FullCalendar.tsx
@@ -179,7 +179,10 @@ const FullCalendar: Component = () => {
                                                         </div>
                                                     </div>
                                                     <Show when={isAdmin()}>
-                                                        <EventMenu eventId={robotEvent.event_id} />
+                                                        <EventMenu
+                                                            eventId={robotEvent.event_id}
+                                                            takeAttendance={robotEvent.take_attendance}
+                                                        />
                                                     </Show>
                                                 </div>
                                                 <Show when={robotEvent.description}>

--- a/src/components/EventMenu.tsx
+++ b/src/components/EventMenu.tsx
@@ -4,7 +4,7 @@ import { HiOutlineMenu } from 'solid-icons/hi'
 import { RouteKeys } from './AppRouting'
 import { formatUrl } from '../utilities/formatters'
 
-type inputs = { eventId: number }
+type inputs = { eventId: number; takeAttendance: boolean }
 const EventMenu: Component<inputs> = (props) => {
     const [show, setShow] = createSignal(false)
     const [searchParams] = useSearchParams()
@@ -29,17 +29,21 @@ const EventMenu: Component<inputs> = (props) => {
                 class="menu absolute top-10 right-2 z-50 dropdown-content shadow bg-base-100 rounded-box w-52 mt-4 border"
                 classList={{ hidden: !show() }}
             >
-                <li>
-                    <A href={formatUrl(RouteKeys.TAKE_ATTENDANCE_ID.nav, { id: props.eventId })} onClick={close}>
-                        Take Attendance
-                    </A>
-                </li>
-                <li>
-                    <A href={formatUrl(RouteKeys.ATTENDANCE_MEETING.nav, { id: props.eventId })} onClick={close}>
-                        Admin Attendance
-                    </A>
-                </li>
-
+                <Show when={props.takeAttendance === true}>
+                    <li>
+                        <A href={formatUrl(RouteKeys.TAKE_ATTENDANCE_ID.nav, { id: props.eventId })} onClick={close}>
+                            Take Attendance
+                        </A>
+                    </li>
+                    <li>
+                        <A href={formatUrl(RouteKeys.ATTENDANCE_MEETING.nav, { id: props.eventId })} onClick={close}>
+                            Admin Attendance
+                        </A>
+                    </li>
+                </Show>
+                <Show when={props.takeAttendance === false}>
+                    <li class="p-4">Attendance NA</li>
+                </Show>
                 <li>
                     <A
                         href={formatUrl(RouteKeys.EVENT_EDIT.nav, { id: props.eventId }, { date: searchParams?.date })}

--- a/src/pages/admin/AttendanceForSeasonByMember.tsx
+++ b/src/pages/admin/AttendanceForSeasonByMember.tsx
@@ -51,9 +51,11 @@ const AttendanceForSeasonByMember: Component<{ season: Accessor<string> }> = (pr
         if (isEmpty(allAttendance())) {
             return 0
         }
-        const data = allAttendance().filter(
-            (record) => record.member_id === memberId && record.attendance !== AttendanceTypes.ABSENT
-        )
+        const data = allAttendance().filter((record) => {
+            const event = eventMap().get(record.event_id)
+            // undefined means the event shouldn't have had attendance records on it
+            return event !== undefined && record.member_id === memberId && record.attendance !== AttendanceTypes.ABSENT
+        })
         return isEmpty(data) ? 0 : data.length
     }
 
@@ -64,7 +66,9 @@ const AttendanceForSeasonByMember: Component<{ season: Accessor<string> }> = (pr
         }
         const data = allAttendance().filter((record) => {
             const event = eventMap().get(record.event_id)
+            // undefined means the event shouldn't have had attendance records on it
             return (
+                event !== undefined &&
                 record.member_id === memberId &&
                 event.event_type === EventTypes.REGULAR_PRACTICE &&
                 record.attendance !== AttendanceTypes.ABSENT
@@ -87,6 +91,9 @@ const AttendanceForSeasonByMember: Component<{ season: Accessor<string> }> = (pr
         setfilteredMembers(sorted)
     })
 
+    createEffect(() => {
+        console.log(allAttendance())
+    })
     // the show prevents race condition when solid can't tell eventMap updated on it's own
     return (
         <Show when={eventMap()?.size > 0 && allAttendance()?.length > 0}>

--- a/src/pages/admin/EventEdit.tsx
+++ b/src/pages/admin/EventEdit.tsx
@@ -1,4 +1,4 @@
-import { Component, createResource, createSignal, Show, Suspense } from 'solid-js'
+import { Component, createEffect, createResource, createSignal, Show, Suspense } from 'solid-js'
 import { EventTypes, EventTypesType } from '../../types/Api'
 import * as yup from 'yup'
 import { useParams, useSearchParams, useNavigate, A } from '@solidjs/router'
@@ -25,6 +25,7 @@ type RobotEvent = {
     end_time: string
     virtual: boolean
     all_day: boolean
+    take_attendance: boolean
 }
 
 // these are the validation rules
@@ -45,6 +46,7 @@ export const eventSchema: yup.SchemaOf<RobotEvent> = yup.object({
     end_time: yup.string().notRequired().nullable(),
     virtual: yup.boolean().required().default(false),
     all_day: yup.boolean().required().default(false),
+    take_attendance: yup.boolean().required().default(false), // will not work defaulting to true
 })
 
 const timeInputHandler = createInputMask('99:99 aa')
@@ -83,6 +85,7 @@ const EventEdit: Component = () => {
                 end_time: formData().end_time,
                 virtual: formData().virtual,
                 all_day: formData().all_day,
+                take_attendance: formData().take_attendance,
             }
             if (robotEvent()?.event_id === undefined) {
                 await saveEvent(updatedEvent)
@@ -198,6 +201,13 @@ const EventEdit: Component = () => {
                                     value={robotEvent()?.description}
                                     formHandler={formHandler}
                                     class="h-24"
+                                />
+
+                                <Checkbox
+                                    label="Take Attendance"
+                                    name="take_attendance"
+                                    checked={robotEvent() === null ? true : robotEvent().take_attendance}
+                                    formHandler={formHandler}
                                 />
                             </div>
                         </form>

--- a/src/types/Api.ts
+++ b/src/types/Api.ts
@@ -138,6 +138,7 @@ type RobotEvent = {
     all_day?: boolean
     virtual?: boolean
     title?: string
+    take_attendance: boolean
 }
 
 export type {


### PR DESCRIPTION
Wanted to have an event on the calendar, but if you didn't want to take attendance, it didn't count in the meeting count. It defaults to true for events. You can turn it off.

- queries changed to limit data coming back
- can't select for attendance an event with this off
- remove from totals