### PR TITLE
prevent multiple attendance for same event by same member

### DIFF
--- a/src/api/attendance.ts
+++ b/src/api/attendance.ts
@@ -56,13 +56,28 @@ const getMemberAttendance = async (eventId: number) => {
  */
 const getAttendance = async (eventId: number) => {
     const { data, error } = await supabase.from('attendance').select().eq('event_id', eventId)
-
     if (error) throw error
-
     if (data.length === 0) {
         return null
     }
     return data as Attendance[]
+}
+
+/**
+ * Check to see if an attendance records exists or not yet. We don't want to insert a second record
+ * for a member on the same event.
+ *
+ * @param eventId number
+ * @param memberId number
+ */
+const checkAttendanceForEvent = async (eventId: number, memberId: number) => {
+    const { data, error } = await supabase
+        .from('attendance')
+        .select('*')
+        .eq('event_id', eventId)
+        .eq('member_id', memberId)
+    if (error) throw error
+    return data.length !== 0
 }
 
 const updateAttendance = async (attendanceId: number, attendanceType: AttendanceTypesType) => {
@@ -70,7 +85,6 @@ const updateAttendance = async (attendanceId: number, attendanceType: Attendance
         .from('attendance')
         .update([{ attendance: attendanceType }])
         .eq('attendance_id', attendanceId)
-
     if (error) throw error
 }
 
@@ -83,7 +97,6 @@ const insertAttendance = async (
     const { data, error } = await supabase
         .from('attendance')
         .insert([{ event_id: eventId, meeting_date: meetingDate, member_id: memberId, attendance: attendanceType }])
-
     if (error) throw error
 }
 
@@ -102,7 +115,6 @@ const getAttendanceForMember = async ({ season, memberId }) => {
         .lte('meeting_date', theEnd)
 
     if (error) throw error
-
     if (data.length === 0) {
         return null
     }
@@ -135,6 +147,7 @@ const getAttendanceForAllMembers = async (season: string) => {
 export {
     getMemberAttendance,
     getAttendance,
+    checkAttendanceForEvent,
     updateAttendance,
     insertAttendance,
     getAttendanceForMember,

--- a/src/components/AttendanceList.tsx
+++ b/src/components/AttendanceList.tsx
@@ -1,6 +1,6 @@
 import { useNavigate } from '@solidjs/router'
 import { Accessor, Component, createEffect, For, Show } from 'solid-js'
-import { insertAttendance, updateAttendance } from '../api/attendance'
+import { checkAttendanceForEvent, insertAttendance, updateAttendance } from '../api/attendance'
 import { AttendanceTypes, AttendanceTypesType, MemberAttendance, SubTeam } from '../types/Api'
 import { capitalizeWord, formatUrl } from '../utilities/formatters'
 import { RouteKeys } from './AppRouting'
@@ -26,7 +26,11 @@ const AttendanceList: Component<{
     const handleClick = async (data: data, event) => {
         event.preventDefault()
         if (data.attendanceId === undefined) {
-            await insertAttendance(props.eventId, props.meetingDate, data.memberId, data.attendanceType)
+            // we don't want to insert if the record is already there - just ignore
+            const existsAlready = await checkAttendanceForEvent(props.eventId, data.memberId)
+            if (!existsAlready) {
+                await insertAttendance(props.eventId, props.meetingDate, data.memberId, data.attendanceType)
+            }
         } else {
             await updateAttendance(data.attendanceId, data.attendanceType)
         }


### PR DESCRIPTION
There was a small possibility that someone could get added twice to the attendance table for the same event. Two people would have to be taking attendance and at very nearly the same time press a button for the same person.