### PR TITLE
move teamList to members and add admin permission checks

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,3 @@
 {
-    "cSpell.words": ["Supabase"]
+    "cSpell.words": ["Supabase", "teamlist"]
 }

--- a/src/calendar/components/MiniDayOfMonthSelect.tsx
+++ b/src/calendar/components/MiniDayOfMonthSelect.tsx
@@ -10,7 +10,7 @@ const MiniDayOfMonthSelect: Component<inputs> = (props) => {
 
     const handleClick = (event) => {
         event.preventDefault()
-        if (isAdmin) {
+        if (isAdmin()) {
             props.handleSelect(props.day)
         }
     }

--- a/src/components/AppRouting.tsx
+++ b/src/components/AppRouting.tsx
@@ -10,7 +10,7 @@ const Welcome = lazy(() => import('../pages/Welcome'))
 const Guest = lazy(() => import('../pages/Guest'))
 const Profile = lazy(() => import('../pages/Profile'))
 const ProfileEdit = lazy(() => import('../pages/members/ProfileEdit'))
-const TeamList = lazy(() => import('../pages/admin/TeamList'))
+const TeamList = lazy(() => import('../pages/members/TeamList'))
 const MemberView = lazy(() => import('../pages/admin/MemberView'))
 const MemberEdit = lazy(() => import('../pages/admin/MemberEdit'))
 const Parents = lazy(() => import('../pages/admin/Parents'))
@@ -60,7 +60,7 @@ export const RouteKeys = {
         regex: /\/members\/attendance\/[0-9]+$/,
         display: 'Take Attendance',
     },
-    TEAM_LIST: { route: '/teamlist', nav: '/admin/teamlist', regex: /\/admin\/teamlist$/, display: 'Team List' },
+    TEAM_LIST: { route: '/teamlist', nav: '/members/teamlist', regex: /\/members\/teamlist$/, display: 'Team List' },
     MEMBER_VIEW: {
         route: '/member/:mid',
         nav: '/admin/member/:mid',
@@ -175,6 +175,7 @@ const AppRouting = () => {
 
             {/* must be a member to view these pages */}
             <Route path="/members" component={MemberAccess}>
+                <Route path={RouteKeys.TEAM_LIST.route} component={TeamList} />
                 <Route path={RouteKeys.PROFILE_EDIT.route} component={ProfileEdit} />
                 <Route path={RouteKeys.TAKE_ATTENDANCE.route} component={AttendancePage} />
                 <Route path={RouteKeys.TAKE_ATTENDANCE_ID.route} component={AttendancePage} />
@@ -183,7 +184,6 @@ const AppRouting = () => {
 
             {/* must be an admin to view these pages */}
             <Route path="/admin" component={AdminAccess}>
-                <Route path={RouteKeys.TEAM_LIST.route} component={TeamList} />
                 <Route path={RouteKeys.MEMBER_VIEW.route} component={MemberView} />
                 <Route path={RouteKeys.MEMBER_EDIT.route} component={MemberEdit} />
                 <Route path={RouteKeys.PARENT_LIST.route} component={Parents} />

--- a/src/components/DisplayTeamDataRow.tsx
+++ b/src/components/DisplayTeamDataRow.tsx
@@ -1,5 +1,6 @@
 import { useNavigate, useSearchParams } from '@solidjs/router'
 import { Component, Show } from 'solid-js'
+import { useNoMythicUser } from '../contexts/UserContext'
 import { Member, SubTeam, TeamRole } from '../types/Api'
 import { capitalizeWord, formatUrl } from '../utilities/formatters'
 import { RouteKeys } from './AppRouting'
@@ -7,16 +8,19 @@ import { RouteKeys } from './AppRouting'
 const DisplayTeamDataRow: Component<{ teamMember: Member }> = (props) => {
     const navigate = useNavigate()
     const [searchParams] = useSearchParams()
+    const { isAdmin } = useNoMythicUser()
 
     type data = { memberId: number }
     const handleClick = async (data: data, _event) => {
-        navigate(formatUrl(RouteKeys.MEMBER_VIEW.nav, { mid: data.memberId }))
+        if (isAdmin()) {
+            navigate(formatUrl(RouteKeys.MEMBER_VIEW.nav, { mid: data.memberId }))
+        }
     }
 
     return (
         <>
             <tr
-                class="hover cursor-pointer hidden lg:table-row"
+                class={`hover ${isAdmin() ? 'cursor-pointer' : ''} hidden lg:table-row`}
                 onClick={[
                     handleClick,
                     {
@@ -31,8 +35,9 @@ const DisplayTeamDataRow: Component<{ teamMember: Member }> = (props) => {
                 <td>{props.teamMember.email}</td>
                 <td>{props.teamMember.phone}</td>
             </tr>
+
             <tr
-                class="hover cursor-pointer lg:hidden"
+                class={`hover ${isAdmin() ? 'cursor-pointer' : ''} lg:hidden`}
                 onClick={[
                     handleClick,
                     {

--- a/src/components/MainMenu.tsx
+++ b/src/components/MainMenu.tsx
@@ -56,6 +56,11 @@ const MainMenu: Component<{ children: JSX.Element }> = (props) => {
                             </li>
                             <Show when={isMember()}>
                                 <li>
+                                    <A href={RouteKeys.TEAM_LIST.nav} onClick={closeMenu}>
+                                        Team List
+                                    </A>
+                                </li>
+                                <li>
                                     <A href={RouteKeys.TAKE_ATTENDANCE.nav} onClick={closeMenu}>
                                         Take Attendance
                                     </A>
@@ -67,11 +72,6 @@ const MainMenu: Component<{ children: JSX.Element }> = (props) => {
                                 </li>
                             </Show>
                             <Show when={isAdmin()}>
-                                <li>
-                                    <A href={RouteKeys.TEAM_LIST.nav} onClick={closeMenu}>
-                                        Team List
-                                    </A>
-                                </li>
                                 <li>
                                     <A href={RouteKeys.TAKE_CHECKIN.nav} onClick={closeMenu}>
                                         Check In

--- a/src/pages/members/TeamList.tsx
+++ b/src/pages/members/TeamList.tsx
@@ -12,12 +12,14 @@ import SubTeamSelector from '../../components/SubTeamSelector'
 import { useSessionContext } from '../../contexts/SessionContext'
 import { RouteKeys } from '../../components/AppRouting'
 import { formatUrl } from '../../utilities/formatters'
+import { useNoMythicUser } from '../../contexts/UserContext'
 
 const TeamList: Component = () => {
     const [filteredTeam, setFilteredTeam] = createSignal<Member[]>([])
     const [year, setYear] = createSignal('2023')
     const [team] = createResource(year, getMembers)
     const [sessionValues] = useSessionContext()
+    const { isAdmin } = useNoMythicUser()
 
     // runs whenever team or subTeam are changed
     createEffect(() => {
@@ -35,16 +37,18 @@ const TeamList: Component = () => {
                     </div>
                     <YearPicker year={year} setYear={setYear} />
                 </div>
-                <div class="flex mt-4 items-end inlign-flex">
-                    <Show when={filteredTeam().length !== 0}>
-                        <div class="flex-none ml-4">Click a row to view</div>
-                    </Show>
-                    <div class="flex flex-auto justify-end">
-                        <A class="btn btn-primary" href={formatUrl(RouteKeys.MEMBER_EDIT.nav, { mid: 0 })}>
-                            Add Member
-                        </A>
+                {isAdmin() && (
+                    <div class="flex mt-4 items-end">
+                        <Show when={filteredTeam().length !== 0}>
+                            <div class="flex-none ml-4">Click a row to view</div>
+                        </Show>
+                        <div class="flex flex-auto justify-end">
+                            <A class="btn btn-primary" href={formatUrl(RouteKeys.MEMBER_EDIT.nav, { mid: 0 })}>
+                                Add Member
+                            </A>
+                        </div>
                     </div>
-                </div>
+                )}
                 <SelectTeamInfoMessage show={filteredTeam().length === 0} extraMessage="Defaults to current season." />
                 <TeamTable teamMembers={filteredTeam} />
             </div>


### PR DESCRIPTION
Wanted to have the team list be visible to all team members, but only the basic data. The click through to the rest of the data would be only for admins.

We might have a couple of people that don't want their phone numbers shared and for now, I will just remove them from the DB once we confirm.